### PR TITLE
Fixed typographical error, changed abilty to ability in README.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -240,7 +240,7 @@ net.ipv4.ip_forward = 1
 If routing is configured correctly on the router, packets should start flowing between the interfaces on the server.
 
 
-This Easy OpenVPN as the abilty to email encypted client config file.  Below is a basic how-to for setting up a Gmail email relay.
+This Easy OpenVPN as the ability to email encypted client config file.  Below is a basic how-to for setting up a Gmail email relay.
 
 # yum install sendmail sendmail-cf cyrus-sasl-plain cyrus-sasl-md5
 


### PR DESCRIPTION
@dad311, I've corrected a typographical error in the documentation of the [Easy-OpenVPN-1.2-OpenVZ-CT](https://github.com/dad311/Easy-OpenVPN-1.2-OpenVZ-CT) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
